### PR TITLE
Update to README to add links to materials and hopefully better readability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
+# Open Omega
+
 Open omega is my attempt at making a passive dynamic headphone that closely adhere's to the DF-HRTF of the B&K 4128C with a 10db downward slope from 20hz-20khz.
 The headphone was originally designed to be made via SLS. I've simplified elements of the design and assembly, making it easier to build at home.
-Video instructions and more info: https://youtu.be/d9SyIJi44J4?si=MpKiYIesISI80hwy
 
-I want to add that Capra has made a 3D printable headband that works with omega. You can find it here: https://www.printables.com/model/1108653-capra-headband-v3/files
+## Materials and Supplies Required
+
+- 3D printed cups (recommended SLS but doable via FDM)
+  - [omega universal cup.stl](./omega%20universal%20cup.stl)
+  - [omega driver cap.stl](./omega%20driver%20cap.stl)
+  - [omega serial plate.stl](./omega%20serial%20plate.stl)
+  - [omega cup rotation limiter.stl](./omega%20cup%20rotation%20limiter.stl)
+- Dekoni LCD Choice suede pads ([Dekoni](dekoniaudio.com/product/choice-suede-ear-pads-for-audeze-lcd-headphones))
+- Dekoni foam attenuation kit ([Dekoni](https://dekoniaudio.com/product/att-foamkit))
+- 304 stainless fine wire mesh 200 mesh, 0.075mm hole, 60µm wire diameter, 34% open area (at least 110mm wide sheet per side) ([Online Metals](https://www.onlinemetals.com/en/buy/stainless-steel/200x200-mesh-0-0021-wire-diameter-stainless-steel-woven-wire-mesh-304/pid/mp-00001984))
+- 3m 468mp adhesive (at least 110mm wide sheet per side) ([Amazon 5" Wide Roll](https://www.amazon.com/468MP-High-Performance-Adhesive-Transfer/dp/B00JL8KTYY), [Gizmo Dorks 8" Square Sheets](https://gizmodorks.com/3m-468mp-adhesive-transfer-tape-sheet-5-pack))
+- Peerless HPD-50N25PR00-32 drivers (pair) ([DigiKey](https://www.digikey.com/en/products/detail/peerless-by-tymphany/HPD-50N25PR00-32/6211129), [Parts Express](https://www.parts-express.com/Peerless-HPD-50N25PR00-32-2-Headphone-Driver-Diaphragm-264-1510))
+- PJ392 3.5mm Jacks ([AliExpress](https://www.aliexpress.us/item/2255800475531472.html), [Amazon](https://www.amazon.com/DAOKI-PJ-392-Stereo-Headphone-Connector/dp/B08XM6DR96))
+- Silicone flexible wire ([Amazon 26AWG](www.amazon.com/BOJACK-Flexible-Silicone-Electric-Stripper/dp/B09Y872KTX))
+- Suitable headband assembly
+- Hot glue or equivalent
+- Soldering iron and solder
+- Laser OR exacto knife for cutting stainless mesh & 3m adhesive
+- Appropriate PPE
+
+## Video instructions and More Info
+
+Click below for instructions on how to assemble the Open Omega and additional background on the project.
+
+[![Click Here](https://img.youtube.com/vi/d9SyIJi44J4/0.jpg)](https://www.youtube.com/watch?v=d9SyIJi44J4)
+
+## Headband
+
+I want to add that Capra has made a 3D printable headband that works with omega. You can find it here:
+
+[https://www.printables.com/model/1108653-capra-headband-v3/files](https://www.printables.com/model/1108653-capra-headband-v3/files)
+
+## Frequency Response
+
+![](./omega%20units%20frequency%20response%20variation.jpg)


### PR DESCRIPTION
Loved the video and thought I'd offer a contribution to make your GitHub page have a better look/readability in markdown. Also added links to places to source materials.

You can preview what this looks like [on my fork here](https://github.com/nuvious/Open-Omega/tree/nuvious-documentation-contribution).

Things I'd like you to review:

- Gauge of wire recommended.
  - I google'd around and saw that 26 AWG seemed to be the sweet spot between regular and 'large' headphones. However you may have a specific gauge and/or stranded vs solid core recommendation.
- Metal mesh vendor link.
  - I tried to find something that fit your description as close as possible, but there may be a more accurate link. Feel free to comment with the specific vendor link you used.
- Order of entries.
  - I tried my best to order things in a way that was readable. Put frequency response at the end because of the size of the image. It could be possible to size that down potentially and move it up above a different section. Also omitted including the logo, but could add it; just need to resize it down a good bit as a separate file.

Any direction on how to adjust things to your liking is welcome. Feel free to just comment with specific links to the parts you ordered or to re-order things in the project. You may also want to (or forego) changing the links to affiliate links if desired.

Thanks again for the awesome video! This is on my bucket list to build someday!